### PR TITLE
fixes for latest videointelligence python client library

### DIFF
--- a/sports_ai/Sports_AI_Analysis.ipynb
+++ b/sports_ai/Sports_AI_Analysis.ipynb
@@ -286,8 +286,7 @@
         "colab": {}
       },
       "source": [
-        "input_uri = os.path.join(bucket, file_to_analyze)\n",
-        "output_uri = os.path.join(bucket, 'output.json')"
+        "input_uri = os.path.join(bucket, file_to_analyze)"
       ],
       "execution_count": null,
       "outputs": []
@@ -302,7 +301,7 @@
       "source": [
         "# This function comes from the docs\n",
         "# https://cloud.google.com/video-intelligence/docs/people-detection\n",
-        "def detect_person(input_uri, output_uri):\n",
+        "def detect_person(input_uri):\n",
         "    \"\"\"Detects people in a video.\"\"\"\n",
         "\n",
         "    client = videointelligence.VideoIntelligenceServiceClient(credentials=service_account.Credentials.from_service_account_file(\n",
@@ -318,13 +317,18 @@
         "\n",
         "    # Start the asynchronous request\n",
         "    operation = client.annotate_video(\n",
-        "        input_uri=input_uri,\n",
-        "        output_uri=output_uri,\n",
-        "        features=[videointelligence.enums.Feature.PERSON_DETECTION],\n",
-        "        video_context=context,\n",
+        "        request={\n",
+        "            \"features\": [videointelligence.Feature.PERSON_DETECTION],\n",
+        "            \"input_uri\": input_uri,\n",
+        "            \"video_context\": context,\n",
+        "        }\n",
         "    )\n",
+        "    \n",
+        "    print(\"\\nProcessing video for person detection annotations.\")\n",
+        "    result = operation.result(timeout=300)\n",
+        "    print(\"\\nAnnotation complete!\")\n",
         "\n",
-        "    return operation\n"
+        "    return result\n"
       ],
       "execution_count": null,
       "outputs": []
@@ -340,7 +344,7 @@
         "# If you get a permissions episode here, you might have to modify the permissions\n",
         "# on your bucket to allow your service account to access it. Do that in the \n",
         "# GCP storage console/UI.\n",
-        "operation = detect_person(input_uri, output_uri)"
+        "operation = detect_person(input_uri)"
       ],
       "execution_count": null,
       "outputs": []
@@ -352,56 +356,8 @@
         "colab_type": "text"
       },
       "source": [
-        "We've called an asynchronous function here--`detect_person`--because long videos can take a while to analyze. You can check the status of the analysis by calling `operation.done`:"
+        "It takes a minute or two for the entire video to be analyzed. Wait for your `detect_person` function to complete and print the `Annotation complete!` message before moving on."
       ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "_So3U0wOcXTN",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "print(f\"Operation ${operation.operation.name} is done? {operation.done()}\")"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eKV3eiI1ci2A",
-        "colab_type": "text"
-      },
-      "source": [
-        "Note that even if you restart this notebook, the Video Intelligence API will still be analyzing your video in the cloud! So you won't lose any progress."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4aHITq4KbvXY",
-        "colab_type": "text"
-      },
-      "source": [
-        "Once the operation is finished, we can download the results from our cloud storage bucket:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "NPfdGwF3b5Hi",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Note! This won't work unless operation.done() == True!\n",
-        "!mkdir tmp\n",
-        "!gsutil cp {output_uri} tmp"
-      ],
-      "execution_count": null,
-      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -420,21 +376,8 @@
         "colab_type": "text"
       },
       "source": [
-        "Results are written to cloud storage as a json file. Let's load them!"
+        "Results are saved as an `AnnotateVideoResponse` object."
       ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "R4EBRYBldpAa",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "data = json.load(open('./tmp/output.json'))"
-      ],
-      "execution_count": null,
-      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -443,7 +386,7 @@
         "colab_type": "text"
       },
       "source": [
-        "These json files are usually pretty big, so don't print them! Instead, let's just inspect the structure:"
+        "These results are usually pretty big, so don't print them! Instead, inspect the structure:"
       ]
     },
     {
@@ -458,9 +401,8 @@
         "outputId": "068c14cb-fca1-4a2e-9b06-f1f55cb0f9b6"
       },
       "source": [
-        "print(data.keys())\n",
-        "# We only care about annotation_results[0] because we only have one video\n",
-        "print(len(data['annotation_results'][0]['person_detection_annotations']))"
+        "# You only care about annotation_results[0] because you only have one video\n",
+        "print(len(operation.annotation_results[0].person_detection_annotations))"
       ],
       "execution_count": null,
       "outputs": [
@@ -481,7 +423,7 @@
         "colab_type": "text"
       },
       "source": [
-        "It's easy to get lost in all these nested fields! What we really want is the data stored in `data['annotation_results`][0][`person_detection_annotations`]. Let's grab it:"
+        "It's easy to get lost in all these nested fields! What we really want is the data stored in `operation.annotation_results[0].person_detection_annotations`. Let's grab it:"
       ]
     },
     {
@@ -492,7 +434,7 @@
         "colab": {}
       },
       "source": [
-        "people_annotations = data['annotation_results'][0]['person_detection_annotations']"
+        "people_annotations = operation.annotation_results[0].person_detection_annotations"
       ],
       "execution_count": null,
       "outputs": []
@@ -521,23 +463,17 @@
         "'''\n",
         "def analyzePerson(person):\n",
         "  frames = []\n",
-        "  for track in person['tracks']:\n",
+        "  for track in person.tracks:\n",
         "    # Convert timestamps to seconds\n",
-        "    for ts_obj in track['timestamped_objects']:\n",
-        "      time_offset = ts_obj['time_offset']\n",
-        "      timestamp = 0\n",
-        "      if 'nanos' in time_offset:\n",
-        "        timestamp += time_offset['nanos'] / 10**9\n",
-        "      if 'seconds' in time_offset:\n",
-        "        timestamp += time_offset['seconds']\n",
-        "      if 'minutes' in time_offset:\n",
-        "        timestamp += time_offset['minutes'] * 60\n",
+        "    for ts_obj in track.timestamped_objects:\n",
+        "      time_offset = ts_obj.time_offset\n",
+        "      timestamp = time_offset.seconds + time_offset.microseconds / 1e6\n",
         "      frame= {'timestamp' : timestamp}\n",
-        "      for landmark in ts_obj['landmarks']:\n",
-        "        frame[landmark['name'] + '_x'] = landmark['point']['x']\n",
+        "      for landmark in ts_obj.landmarks:\n",
+        "        frame[landmark.name + '_x'] = landmark.point.x\n",
         "        # Subtract y value from 1 because positions are calculated\n",
         "        # from the top left corner\n",
-        "        frame[landmark['name'] + '_y'] = 1 - landmark['point']['y']\n",
+        "        frame[landmark.name + '_y'] = 1 - landmark.point.y\n",
         "      frames.append(frame)\n",
         "  sorted(frames, key=lambda x: x['timestamp'])\n",
         "  return frames"
@@ -563,8 +499,8 @@
         "colab": {}
       },
       "source": [
-        "annotationsPd = pd.DataFrame(analyzePerson(people_annotations[0]))\n",
-        "for annotation in people_annotations[1:]:\n",
+        "annotationsPd = pd.DataFrame()\n",
+        "for annotation in people_annotations:\n",
         "  annotationsPd = annotationsPd.append(pd.DataFrame(analyzePerson(annotation)))\n",
         "\n",
         "annotationsPd = annotationsPd.sort_values('timestamp', ascending=True)"
@@ -1408,7 +1344,7 @@
         "outputId": "b7071740-6c2d-4fd5-c5fe-e0071c509ef4"
       },
       "source": [
-        "!mkdir tmp/snapshots\n",
+        "!mkdir -p tmp/snapshots\n",
         "!ffmpeg -i {filename} -vf fps=20 -ss 00:00:01 -t 00:00:02 tmp/snapshots/%03d.jpg"
       ],
       "execution_count": null,


### PR DESCRIPTION
The `videointelligence_v1p3beta1` client library had a few significant changes that broke the original notebook we were using. Most importantly, the `annotate_video` function doesn't take an `output_uri` parameter anymore. There may be a better solution, but I adjusted the notebook to work without saving/loading the results to/from a storage bucket.